### PR TITLE
Fix broken link to ansible docs.

### DIFF
--- a/deployment/install.rst
+++ b/deployment/install.rst
@@ -118,7 +118,7 @@ This leaves you in a show where you can run docker-compose logs and other docker
 Notes and Provisos
 ------------------
 
-The general installation steps can be reviewed in the `Ansible <https://github.com/rackn/digitalrebar-deploy/edit/master/install/ansible.rst>`_ playbook docs.
+The general installation steps can be reviewed in the `Ansible <install/ansible.rst>`_ playbook docs.
 
     To improve support, the `Digital Rebar team <https://github.com/orgs/digitalrebar/teams>`_ is no longer creating or documenting install packages.
 


### PR DESCRIPTION
One of the links at the end was broken - fixed it by copying the similar link near the top of the install doc.