### PR TITLE
add workloads guide - focus on general use and k8s

### DIFF
--- a/BOOK.rst
+++ b/BOOK.rst
@@ -17,6 +17,7 @@ The **Digital Rebar Project** is a container-ready, infrastructure-as-code provi
    arch/README
    deployment/README
    user/README
+   workloads/README
    contrib/README
    development/README
    faq/README

--- a/workloads/README.rst
+++ b/workloads/README.rst
@@ -1,0 +1,69 @@
+.. _workloads_guide:
+
+Platform Workloads
+==================
+
+This guide will describe how to install and use Digital Rebar Workloads.
+
+Workloads are groups of roles that deliver specific functionality such as platform as a service, container management and storage services.  They maybe often used in combination so users should expect to install multiple workloads together.
+
+.. toctree::
+   :glob:
+   :numbered:
+   :maxdepth: 2
+
+   kubernetes/README
+   swarm/README
+   mesos/README
+
+General Installation
+--------------------
+
+Workloads are require a specific set of roles to be included in the Digital Rebar server before they can run.  Make sure that your server has been started with those roles in place.  We are actively making it easier to add roles, so workload scripts will soon be able to upload the needed roles as part of their installation.
+
+Install workloads you need the Digital Rebar Deploy infrastructure:
+
+  ::
+  
+  	mkdir ~/digitalrebar
+  	cd ~/digitalrebar
+  	git clone https://github.com/rackn/digitalrebar-deploy deploy
+
+Note: You can use ``--help`` to get a full list of options.
+
+The following options are common for all workload scripts:
+
+  * ``--deploy-admin=[provider]`` tells the script to create a new DR admin server on the provider specified.
+  * ``--admin-ip=[ip]`` allows the script to use an existing DR admin server.  Generally, this is used with the ``--deployment-name`` option
+  * ``--deployment-name=[name]`` sets the deployment for the workload.  This is needed when you are testing multiple workloads on the same admin server.  It also determines the names of the nodes created.
+
+RECOMMENDATION: You can provide useful defaults for these scripts in your :ref:`dr_info` file.  This is also helpful to store your provider credentials.
+
+For example, to install the :ref:`kubernetes_workload`, use:
+
+  ::
+
+  	cd ~/digitalrebar/deploy
+  	workloads/kubernetes.sh --deploy-admin=google --provider=aws --deployment-name=rebarrocks
+
+Using A Running DR Admin
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+While workloads scripts often include a Digital Rebar admin setup (see :ref:`install`), it saves time if you already have a working admin node.  You can tell the scripts to use the admin node using ``--admin-ip=[ip]``.
+
+Cleaning Up
+~~~~~~~~~~~
+
+Workloads respect the ``--teardown=true`` instruction to remove a workload.  Make sure to include the same ``--deployment-name``!  This only works if you've used the ``--deploy-admin`` option.
+
+If you want to keep the Admin node running for additional deployments, include the ``--keep-admin=true`` flag.  It defaults to _false_.
+
+Providers
+~~~~~~~~~
+
+Workloads need to :ref:`ug_add_provider`, so expect that you will need to specify a provider.
+
+Developer Note
+--------------
+
+The remote install and workload scripts do NOT play well with doing local development using :ref:`docker_admin`.  You should create a second deployment clone if you are using ``tools/docker-admin`` which takes over the ``../deployment`` directory.

--- a/workloads/README.rst
+++ b/workloads/README.rst
@@ -12,58 +12,9 @@ Workloads are groups of roles that deliver specific functionality such as platfo
    :numbered:
    :maxdepth: 2
 
+   installation
    kubernetes/README
    swarm/README
    mesos/README
-
-General Installation
---------------------
-
-Workloads are require a specific set of roles to be included in the Digital Rebar server before they can run.  Make sure that your server has been started with those roles in place.  We are actively making it easier to add roles, so workload scripts will soon be able to upload the needed roles as part of their installation.
-
-Install workloads you need the Digital Rebar Deploy infrastructure:
-
-  ::
-  
-  	mkdir ~/digitalrebar
-  	cd ~/digitalrebar
-  	git clone https://github.com/rackn/digitalrebar-deploy deploy
-
-Note: You can use ``--help`` to get a full list of options.
-
-The following options are common for all workload scripts:
-
-  * ``--deploy-admin=[provider]`` tells the script to create a new DR admin server on the provider specified.
-  * ``--admin-ip=[ip]`` allows the script to use an existing DR admin server.  Generally, this is used with the ``--deployment-name`` option
-  * ``--deployment-name=[name]`` sets the deployment for the workload.  This is needed when you are testing multiple workloads on the same admin server.  It also determines the names of the nodes created.
-
-RECOMMENDATION: You can provide useful defaults for these scripts in your :ref:`dr_info` file.  This is also helpful to store your provider credentials.
-
-For example, to install the :ref:`kubernetes_workload`, use:
-
-  ::
-
-  	cd ~/digitalrebar/deploy
-  	workloads/kubernetes.sh --deploy-admin=google --provider=aws --deployment-name=rebarrocks
-
-Using A Running DR Admin
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-While workloads scripts often include a Digital Rebar admin setup (see :ref:`install`), it saves time if you already have a working admin node.  You can tell the scripts to use the admin node using ``--admin-ip=[ip]``.
-
-Cleaning Up
-~~~~~~~~~~~
-
-Workloads respect the ``--teardown=true`` instruction to remove a workload.  Make sure to include the same ``--deployment-name``!  This only works if you've used the ``--deploy-admin`` option.
-
-If you want to keep the Admin node running for additional deployments, include the ``--keep-admin=true`` flag.  It defaults to _false_.
-
-Providers
-~~~~~~~~~
-
-Workloads need to :ref:`ug_add_provider`, so expect that you will need to specify a provider.
-
-Developer Note
---------------
-
-The remote install and workload scripts do NOT play well with doing local development using :ref:`docker_admin`.  You should create a second deployment clone if you are using ``tools/docker-admin`` which takes over the ``../deployment`` directory.
+   parameters
+   troubleshooting

--- a/workloads/installation.rst
+++ b/workloads/installation.rst
@@ -1,0 +1,31 @@
+.. _workloads_installation:
+
+General Installation
+--------------------
+
+Workloads are require a specific set of roles to be included in the Digital Rebar server before they can run.  Make sure that your server has been started with those roles in place.  We are actively making it easier to add roles, so workload scripts will soon be able to upload the needed roles as part of their installation.
+
+All workload scripts leverage the Digital Rebar annealer to coordinate work.  That means that all of the requested tasks are loaded into the system as quickly as possible: generally as soon as the node placeholders appear but before they are fully provisioned.  Once the work has been queued, the scripts have completed their function.  By default, the scripts will appear to continue acting as they monitor the annealer.  During this time, users could stop the script and login to Rebar to monitor progress themselves.
+
+Install workloads you need the Digital Rebar Deploy infrastructure:
+
+  ::
+
+  	mkdir ~/digitalrebar
+  	cd ~/digitalrebar
+  	git clone https://github.com/rackn/digitalrebar-deploy deploy
+
+If you have added AWS provider credentials to :ref:`dr_info` then you could then deploy a Kubernetes workload as follows (see :ref:`kubernetes_workload` for mre details):
+
+   :: 
+
+  	cd ~/digitalrebar/deploy
+  	workloads/kubernetes.sh --deploy-admin=aws --provider=aws --deployment-name=rebarrocks
+
+Read more about :ref:`workload_parameters` or you can use ``--help`` to get a full list of options.
+
+
+Developer Notes
+~~~~~~~~~~~~~~~
+
+The remote install and workload scripts do NOT play well with doing local development using :ref:`docker_admin`.  You should create a second deployment clone if you are using ``tools/docker-admin`` which takes over the ``../deployment`` directory.

--- a/workloads/kubernetes/README.rst
+++ b/workloads/kubernetes/README.rst
@@ -1,0 +1,19 @@
+.. _kubernetes_workload:
+
+Kubernetes Workload
+===================
+
+`Kubernetes <http://kubernetes.io/>`_ is a container orchestration and management platform.
+
+This section is specific to Kubernetes, see :ref:`workloads_guide` for general install tips.
+
+Installation
+------------
+
+Install the Kubernetes workload, run the workload script:
+
+  ::
+  
+  	cd ~/digitalrebar/deploy
+  	workloads/kubernetes.sh --deploy-admin=google --provider=aws --deployment-name=kubeup
+

--- a/workloads/kubernetes/README.rst
+++ b/workloads/kubernetes/README.rst
@@ -13,7 +13,15 @@ Installation
 Install the Kubernetes workload, run the workload script:
 
   ::
-  
+
   	cd ~/digitalrebar/deploy
   	workloads/kubernetes.sh --deploy-admin=google --provider=aws --deployment-name=kubeup
 
+Video Examples
+--------------
+
+Rob Hirschfeld has created a `number of videos <https://www.youtube.com/playlist?list=PLXPBeIrpXjfh2lXdXkNnzAuc7_SUtYJR->`_ showing how these scripts work.
+
+  * `Deploy on Multiple OpenStack Clouds from Same Platform (demo of Kubernetes) <https://www.youtube.com/watch?v=LIm6PD9c7NQ&index=2&list=PLXPBeIrpXjfjabMbwYyDULOX3kZmlxEXK>`_
+  * `Hybrid @Kubernetesio: @OpenStack #Google #AWS <https://www.youtube.com/watch?v=C4-H1DZEQFc&index=1&list=PLXPBeIrpXjfjabMbwYyDULOX3kZmlxEXK>`_
+  * `Digital Rebar Kubernetes "Easy Button" CLI - three clouds, two SDNs <https://www.youtube.com/watch?v=3qnf_OfNhHE&index=2&list=PLXPBeIrpXjfh2lXdXkNnzAuc7_SUtYJR->`_

--- a/workloads/kubernetes/README.rst
+++ b/workloads/kubernetes/README.rst
@@ -17,6 +17,8 @@ Install the Kubernetes workload, run the workload script:
   	cd ~/digitalrebar/deploy
   	workloads/kubernetes.sh --deploy-admin=google --provider=aws --deployment-name=kubeup
 
+Since the Kubernetes workload uses Ansible, it does not require the nodes to access an Admin node.  This allows users to run a local Admin node and provision Kubernetes to external nodes.  WARNING: A local admin requires consistent connectivity to the nodes to work - it cannot disconnect even when the script changes to waiting to anneal mode.
+
 Video Examples
 --------------
 
@@ -29,24 +31,31 @@ Rob Hirschfeld has created a `number of videos <https://www.youtube.com/playlist
 Configuration Options
 ---------------------
 
+We've worked hard to create safe defaults; however, if you change defaults then the downstream consumers of those values will get the correct values.
+
 General Options
 ~~~~~~~~~~~~~~~
 
   * ``--kubernetes-master-count=<Number>`` Number of masters to start
   * ``--kubernetes-bin-dir=<String>`` Directory to store binaries ``/usr/local/bin``
-  * ``--kubernetes-cloud-provider=<String>`` Is kubernetes in a cloud environment (false or type)
-  * ``--kubernetes-cloud-provider-type=<String>`` Which cloud environment
   * ``--kubernetes-cluster-logging=<true|false>`` Use cluster logging
   * ``--kubernetes-cluster-monitoring=<true|false>`` Use cluster monitoring
   * ``--kubernetes-cluster-name=<String>`` Name of cluster: cluster.local
-  * ``--kubernetes-kube-service-addresses=<CIDRIP>`` Internal Service IP Addresses
   * ``--kubernetes-local-release-dir=<String>`` Directory to download binaries: /tmp/releases
   * ``--kubernetes-log-level=<Int>  : Kubernetes Log Level: 2
   * ``--kubernetes-test=<true|false>`` Add the test role to validate completion
   * ``--kubernetes-users=<String>   : JSON string of users with password and role
 
+The following options are set by the script.  Override with caution!
+
+  * ``--kubernetes-kube-service-addresses=<CIDRIP>`` Internal Service IP Addresses
+  * ``--kubernetes-cloud-provider=<String>`` Is kubernetes in a cloud environment (false or type)
+  * ``--kubernetes-cloud-provider-type=<String>`` Which cloud environment
+
 Prerequisites 
 ~~~~~~~~~~~~~
+
+In the future, you should be able to use an existing Etcd cluster.
 
   * ``--kubernetes-etcd-client-port=<Int>`` Default etcd client port: 2379
   * ``--kubernetes-etcd-peer-port=<Int>`` Default etcd peer port: 2380
@@ -67,7 +76,10 @@ Networking Options
 
 There are a lot of networking options for Kubernetes and they are constantly evolving.
 
-  * ``--kubernetes-networking=<calico|flannel|opencontrail>`` Network mode to use
+There are the primary ones are generally set by users:
+
+  * ``--kubernetes-networking=<calico|flannel|opencontrail>`` Network mode to use.  Defaults to flannel.
+  * ``--kubernetes-dns=<true|false>`` Use DNS add-on. Defaults to true.
   * ``--kubernetes-network-category=<category name>`` Network category to use for underlay traffic, default: admin
 
 DNS configuration: 
@@ -75,7 +87,6 @@ DNS configuration:
   * ``--kubernetes-dns-domain=<Domain String>`` Domain of the internal Kubernetes DNS service
   * ``--kubernetes-dns-namespace=<Kuberetenes Namespace>`` Namespace to put the DNS service in
   * ``--kubernetes-dns-replicas=<Number>`` Number of DNS replicas to run
-  * ``--kubernetes-dns=<true|false>`` Use DNS add-on
   * ``--kubernetes-dns-upstream=<JSON ARRAY of IP>`` JSON array of DNS server IPs
 
 Calico or Flannel:

--- a/workloads/kubernetes/README.rst
+++ b/workloads/kubernetes/README.rst
@@ -25,3 +25,72 @@ Rob Hirschfeld has created a `number of videos <https://www.youtube.com/playlist
   * `Deploy on Multiple OpenStack Clouds from Same Platform (demo of Kubernetes) <https://www.youtube.com/watch?v=LIm6PD9c7NQ&index=2&list=PLXPBeIrpXjfjabMbwYyDULOX3kZmlxEXK>`_
   * `Hybrid @Kubernetesio: @OpenStack #Google #AWS <https://www.youtube.com/watch?v=C4-H1DZEQFc&index=1&list=PLXPBeIrpXjfjabMbwYyDULOX3kZmlxEXK>`_
   * `Digital Rebar Kubernetes "Easy Button" CLI - three clouds, two SDNs <https://www.youtube.com/watch?v=3qnf_OfNhHE&index=2&list=PLXPBeIrpXjfh2lXdXkNnzAuc7_SUtYJR->`_
+
+Configuration Options
+---------------------
+
+General Options
+~~~~~~~~~~~~~~~
+
+  * ``--kubernetes-master-count=<Number>`` Number of masters to start
+  * ``--kubernetes-bin-dir=<String>`` Directory to store binaries ``/usr/local/bin``
+  * ``--kubernetes-cloud-provider=<String>`` Is kubernetes in a cloud environment (false or type)
+  * ``--kubernetes-cloud-provider-type=<String>`` Which cloud environment
+  * ``--kubernetes-cluster-logging=<true|false>`` Use cluster logging
+  * ``--kubernetes-cluster-monitoring=<true|false>`` Use cluster monitoring
+  * ``--kubernetes-cluster-name=<String>`` Name of cluster: cluster.local
+  * ``--kubernetes-kube-service-addresses=<CIDRIP>`` Internal Service IP Addresses
+  * ``--kubernetes-local-release-dir=<String>`` Directory to download binaries: /tmp/releases
+  * ``--kubernetes-log-level=<Int>  : Kubernetes Log Level: 2
+  * ``--kubernetes-test=<true|false>`` Add the test role to validate completion
+  * ``--kubernetes-users=<String>   : JSON string of users with password and role
+
+Prerequisites 
+~~~~~~~~~~~~~
+
+  * ``--kubernetes-etcd-client-port=<Int>`` Default etcd client port: 2379
+  * ``--kubernetes-etcd-peer-port=<Int>`` Default etcd peer port: 2380
+
+Pod Configuration & UI
+~~~~~~~~~~~~~~~~~~~~~~
+
+Digital Rebar is able to perform post-install configuaration and testing.  These flags are used to configure pods on the Kubernetes cluster after is has been installed.  The sequence is handled by the Digital Rebar annealer, the script pre-loads all requests and does not hold work.
+
+  * ``--kubernetes-dashboard=<true|false>`` Use Kubernetes-Dashboard (default UI now)
+  * ``--kubernetes-dash=<true|false>`` Use Kube-Dash
+  * ``--kubernetes-fabric8=<true|false>`` Use Fabric8 console
+  * ``--kubernetes-guestbook=<true|false>`` Add the guestbook role to start a guestbook app
+  * ``--kubernetes-ui=<true|false>  : Use Kube-UI - deprecated but still works
+
+Networking Options
+~~~~~~~~~~~~~~~~~~
+
+There are a lot of networking options for Kubernetes and they are constantly evolving.
+
+  * ``--kubernetes-networking=<calico|flannel|opencontrail>`` Network mode to use
+  * ``--kubernetes-network-category=<category name>`` Network category to use for underlay traffic, default: admin
+
+DNS configuration: 
+
+  * ``--kubernetes-dns-domain=<Domain String>`` Domain of the internal Kubernetes DNS service
+  * ``--kubernetes-dns-namespace=<Kuberetenes Namespace>`` Namespace to put the DNS service in
+  * ``--kubernetes-dns-replicas=<Number>`` Number of DNS replicas to run
+  * ``--kubernetes-dns=<true|false>`` Use DNS add-on
+  * ``--kubernetes-dns-upstream=<JSON ARRAY of IP>`` JSON array of DNS server IPs
+
+Calico or Flannel:
+
+  * ``--kubernetes-pods-subnet=<CIDRIP>`` Subnet whole calico/flannel subnet space (dotted quad)
+  * ``--kubernetes-network-node-prefix=<Number>`` Subnet prefix for node calico/flannel subnet space
+  * ``--kubernetes-network-prefix=<Number>`` Subnet prefix for whole calico/flannel subnet space
+  * ``--kubernetes-node-count=<Number>`` Number of nodes to start
+
+OpenContrail:
+
+When using OpenContrail, the script will create additional nodes to handle the needed gateway services.
+
+  * ``--kubernetes-gateway-count=<Number>`` Number of gateway nodes to start (opencontrail only)
+  * ``--kubernetes-opencontrail-no-arp=<true|false>`` Should opencontrail arp or not: Google should not.  Make true for that.
+  * ``--kubernetes-opencontrail-private-subnet=<CIDRIP>`` Private network space for opencontrail
+  * ``--kubernetes-opencontrail-public-subnet=<CIDRIP>`` Public network space for opencontrail
+

--- a/workloads/mesos/README.rst
+++ b/workloads/mesos/README.rst
@@ -1,0 +1,10 @@
+.. _mesos_workload:
+
+Mesos & DC/OS Workload
+======================
+
+.. index:
+  TODO; Describe_Mesos
+
+
+How to install Mesos DC/OS

--- a/workloads/parameters.rst
+++ b/workloads/parameters.rst
@@ -1,0 +1,68 @@
+.. _workloads_parameters:
+
+Optional Parameters 
+-------------------
+
+The following options are common for all workload scripts:
+
+  * ``--deploy-admin=[provider]`` tells the script to create a new DR admin server on the provider specified.
+  * ``--admin-ip=[ip]`` allows the script to use an existing DR admin server.  Generally, this is used with the ``--deployment-name`` option
+  * ``--deployment-name=[name]`` sets the deployment for the workload.  This is needed when you are testing multiple workloads on the same admin server.  It also determines the names of the nodes created.
+  * ``--wait-on-converge=true|false`` tells the script to wait for converge work created by the script.  This assumes that the admin is only doing one script at a time and is not recommended for CI/CD testing or parallel testing.  Defaults to ``true``
+  * ``--rebar-password=<String>`` sets the password to access the rebar system.  Defaults to ``rebar1``.
+  * ``--rebar-user=<String>`` changes the Username to access the rebar system.  Defaults to ``rebar``.
+
+RECOMMENDATIONS: 
+
+  * You can provide defaults for these settings scripts in your :ref:`dr_info` file that is also used to store your provider credentials.
+  * Since the scripts will automatically install the :ref:`rebar_cli`, you can use CLI commands to access and test your cluster using the Admin End Point URL.
+
+For example, to install the :ref:`kubernetes_workload`, use:
+
+  ::
+
+  	cd ~/digitalrebar/deploy
+  	workloads/kubernetes.sh --deploy-admin=google --provider=aws --deployment-name=rebarrocks
+
+You can interrupt the script while it is waiting to converge without impacting the deployment operation.
+
+Using A Running DR Admin
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+While workloads scripts often include a Digital Rebar admin setup (see :ref:`install`), it saves time if you already have a working admin node.  You can tell the scripts to use the admin node using ``--admin-ip=[ip]``.
+
+Cleaning Up
+~~~~~~~~~~~
+
+Workloads respect the ``--teardown`` instruction to remove a workload.  Make sure to include the same ``--deployment-name``!  This only works if you've used the ``--deploy-admin`` option.
+
+If you want to keep the Admin node running for additional deployments, include the ``--keep-admin=true`` flag.  It defaults to _false_.
+
+Providers
+~~~~~~~~~
+
+Workloads need to :ref:`ug_add_provider`, so expect that you will need to specify a provider.
+
+  * ``--device-id=<String>`` allows users to continue an aborted script against a node that was created by a provider in a previous run.  This is very handy when debugging scripts.
+  * ``--init-id-file=<file>`` File that defines the initial identity used to log into the node after provider provisioning.  The scripts will generally handle this automatically and this setting can be used if the provider limits the number of keys that can be used.
+
+AWS Specific Options:
+
+  * ``--provider-aws-admin-instance-type`` allows you to set AWS instance type to use for admin nodes.  This is important if you are running large tests and want extra resources.
+  * ``--provider-aws-instance-type`` allows you to set AWS instance type to use for nodes to match your performance needs.
+  * ``--provider-aws-region`` chooses region to use for nodes
+
+Google Specific Options:
+
+  * ``--provider-google-admin-instance-type`` allows you to set Google instance type to use for admin nodes.  This is important if you are running large tests and want extra resources.
+  * ``--provider-google-instance-type`` allows you to set Google instance type to use for nodes to match your performance needs.
+  * ``--provider-google-zone`` chooses zone to use for nodes
+
+Advanced Options
+~~~~~~~~~~~~~~~~
+
+These options provide extra control for the Digital Rebar installation.
+
+  * ``--dns-domain`` Domain name setting is important if you need your nodes to join a larger DNS infrastructure.  Defaults to ``neode.local``
+  * ``--dr_tag=<TAG>`` if you are running stable or special branches, then pick a build tag to use for digitalrebar. default: ``latest``
+  * ``--id-file=<file>`` picks the SSH Identity file to use to log into the node to ensure keys are in place.  This is useful if you have multple SSH identities.

--- a/workloads/swarm/README.rst
+++ b/workloads/swarm/README.rst
@@ -1,0 +1,10 @@
+.. _swarm_workload:
+
+Docker Swarm Workload
+=====================
+
+.. index:
+  TODO; Describe_Docker_Swarm
+
+
+Install the Docker Swarm workload from the ``digitalrebar/deploy`` directory using the ``workloads/docker-swarm.sh`` script.

--- a/workloads/swarm/README.rst
+++ b/workloads/swarm/README.rst
@@ -8,3 +8,25 @@ Docker Swarm Workload
 
 
 Install the Docker Swarm workload from the ``digitalrebar/deploy`` directory using the ``workloads/docker-swarm.sh`` script.
+
+Installation
+------------
+
+This section is specific to Docker-Swarm, see :ref:`workloads_guide` for general install tips.
+
+   :: 
+
+  	cd ~/digitalrebar/deploy
+  	workloads/docker-swarm.sh --deploy-admin=aws --provider=aws --deployment-name=rebarrolls
+
+
+Bidirectional Admin
+~~~~~~~~~~~~~~~~~~~ 
+
+The Docker Swarm install uses Chef script.  For this reason, the nodes must have access to the Admin.
+
+Options
+~~~~~~~
+
+  * ``--docker-swarm-manager-count=<Number>`` Number of managers to start
+  * ``--docker-swarm-member-count=<Number>`` Number of members to start

--- a/workloads/troubleshooting.rst
+++ b/workloads/troubleshooting.rst
@@ -1,0 +1,23 @@
+.. _workloads_troubleshooting:
+
+Troubleshooting
+---------------
+
+There are several possible failures when running Workload scripts.
+
+SSH Key
+~~~~~~~
+
+If you are having trouble getting your SSH keys to work correctly, you may need to include the ``--clean-ids`` flag in the script.  
+
+Rebar creates a unique SSH key for each node created; consequently, you may also have orphaned Rebar SSH IDs with your provider.  These can be safely removed with the Provider UI or CLI.
+
+Provider Failure
+~~~~~~~~~~~~~~~~
+
+Provider node allocation sometimes fails.  In these cases, the annealer will be stuck waiting for a node that never completes.  For worker nodes, you can simply ``destroy`` the node and processing will continue.  If the node was a master node, you may need to destroy the whole deployment and retry.
+
+Script Failure
+~~~~~~~~~~~~~~
+
+If the script fails to complete after it has created the Digital Rebar Admin node and before it completed Admin configuration, you can retry the script by providing the ``--device-id`` instead of ``--deploy-admin``.  This will tell the script retry the Rebar Admin setup.


### PR DESCRIPTION
catching up on k8s install documentation.  this is a starting point with the basics.

using xref makes it easier for users to leverage what we've already done.