### PR TITLE
Fixed error caused by syntax

### DIFF
--- a/development/contributing/contributing-docs.rst
+++ b/development/contributing/contributing-docs.rst
@@ -6,7 +6,7 @@
 Contributing Docs
 -----------------
 
-As always, please follow the basic git setup to start: :ref:`contrib_basic`.
+As always, please follow the basic git setup at :ref:`contrib_basic` to start.
 
 Edit Documentation
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There was a colon before a cross reference link, so the command was shown.