### PR TITLE
Possible wrong link fix

### DIFF
--- a/intro/videos.rst
+++ b/intro/videos.rst
@@ -17,7 +17,7 @@ Digital Rebar Overview & Demos
 
 https://www.youtube.com/playlist?list=PLXPBeIrpXjfhIEF7IarSubtcOPFd4e3IB
 
-Kubenetes Specific Content
+Kubernetes Specific Content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 https://www.youtube.com/playlist?list=PLXPBeIrpXjfjabMbwYyDULOX3kZmlxEXK

--- a/intro/videos.rst
+++ b/intro/videos.rst
@@ -15,7 +15,7 @@ https://www.youtube.com/playlist?list=PLXPBeIrpXjfgurJuwVjZkcfmatCoXYM_v
 Digital Rebar Overview & Demos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-https://www.youtube.com/playlist?list=PLXPBeIrpXjfgurJuwVjZkcfmatCoXYM_v
+https://www.youtube.com/playlist?list=PLXPBeIrpXjfhIEF7IarSubtcOPFd4e3IB
 
 Kubenetes Specific Content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I think that the "Digital Rebar Overview and Demos" links to the wrong playlist, as the "Training Videos" also links there... I changed the link to what I believe it was supposed to be.

Also, there was a typo that I fixed.